### PR TITLE
Feat, Design, Fix: 축제 일정 페이지

### DIFF
--- a/pages/Schedule/index.tsx
+++ b/pages/Schedule/index.tsx
@@ -1,7 +1,58 @@
-import React from "react";
+import HeaderBar from "@components/HeaderBar";
+import React, { useState } from "react";
+import { StyledDivColumn, StyledDivRow } from "../../Style/FlexBox";
+import { Wrapper } from "../../Style/Wrapper";
+import { Calendar, DateBox, DetailInfo, Info, Span } from "./styles";
+
 
 const Schedule = () => {
-  return <div>스케줄페이지</div>;
+const [dates,setDates] = useState([{date: 1, fests: ["딸기 축제", "불꽃 축제"]}, {date: 2, fests: []}, {date: 3, fests: []}, {date: 4, fests: []}, {date: 5, fests: []}, {date: 6, fests: []}, {date: 7, fests: []}, {date: 8, fests: []}, {date: 9, fests: []}, {date: 10, fests: []}, {date: 11, fests: []}, {date: 12, fests: []}, {date: 13, fests: []}, {date: 14, fests: []}, {date: 15, fests: []}, {date: 16, fests: []}, {date: 17, fests: []}, {date: 18, fests: []}, {date: 19, fests: []}, {date: 20, fests: []}, {date: 21, fests: []}, {date: 22, fests: []}, {date: 23, fests: []}, {date: 24, fests: []}, {date: 25, fests: []}, {date: 26, fests: []}, {date: 27, fests: []}, {date: 28, fests: []}, {date: 29, fests: []}, {date: 30, fests: []}, {date: 31, fests: []}])
+
+// 현재 날짜 구하기
+let now = new Date();
+let year = now.getFullYear()
+let month = now.getMonth()
+const monthEn = ["JANUARY", "FEBRUARY", "MARCH", "APRIIL", "MAY", "JUNE", "JULY", "AUGUST" ,"SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"]
+let monthWord = monthEn[month]
+
+  const calendar = dates.map((d: any) => {
+let festivals = d.fests
+    const list = festivals.map((f:string) => {
+      return<li style={{fontSize: "2rem", listStyleType: "disc", listStylePosition: "outside",  marginBottom: "1.1rem"}}>{f}</li>})
+    return <DateBox id={d.date.toString()}>
+      <span>{d.date}</span>
+      {/* 오류 수정 필요 */}
+      <ul style={{    margin: 0, padding: 0, marginTop: "1.1rem", marginLeft: "1rem"}}>
+        {list}
+      </ul>
+    </DateBox>
+  })
+
+  return <>
+          <HeaderBar />
+          <Wrapper style={{height: "100%",width: "90%",marginTop: 0,paddingTop: "7%", paddingLeft: "7rem", alignItems: "center", justifyContent: "center"}}>
+      <StyledDivRow style={{width: "100%", justifyContent: "space-around", marginBottom: "3%"}}>
+        <StyledDivColumn>
+      <Span>축제 일정</Span>
+<Span style={{fontSize: "2.5rem"}}>{year}년 {month}월</Span>
+</StyledDivColumn>
+<Span style={{fontSize: "4rem"}}>{monthWord}</Span>
+<div></div>
+</StyledDivRow>
+<StyledDivRow>
+<Calendar>
+{calendar}
+</Calendar>
+<DetailInfo>
+<Info></Info>
+<Info>장소 </Info>
+<Info>축제 기간</Info>
+<Info>축제 시간</Info>
+<Info>가격</Info>
+</DetailInfo>
+</StyledDivRow>
+</Wrapper>
+  </>;
 };
 
 export default Schedule;

--- a/pages/Schedule/index.tsx
+++ b/pages/Schedule/index.tsx
@@ -1,6 +1,6 @@
 import HeaderBar from "@components/HeaderBar";
 import React, { useEffect, useState } from "react";
-import { useAppDispatch, useAppSelector } from "redux/hooks";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { StyledDivColumn, StyledDivRow } from "../../Style/FlexBox";
 import { Wrapper } from "../../Style/Wrapper";
 import { getFesInfo } from "./infoSlice";

--- a/pages/Schedule/index.tsx
+++ b/pages/Schedule/index.tsx
@@ -1,12 +1,23 @@
 import HeaderBar from "@components/HeaderBar";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useAppDispatch, useAppSelector } from "redux/hooks";
 import { StyledDivColumn, StyledDivRow } from "../../Style/FlexBox";
 import { Wrapper } from "../../Style/Wrapper";
+import { getFesInfo } from "./infoSlice";
 import { Calendar, DateBox, DetailInfo, Info, Span } from "./styles";
 
 
 const Schedule = () => {
 const [dates,setDates] = useState([{date: 1, fests: ["딸기 축제", "불꽃 축제"]}, {date: 2, fests: []}, {date: 3, fests: []}, {date: 4, fests: []}, {date: 5, fests: []}, {date: 6, fests: []}, {date: 7, fests: []}, {date: 8, fests: []}, {date: 9, fests: []}, {date: 10, fests: []}, {date: 11, fests: []}, {date: 12, fests: []}, {date: 13, fests: []}, {date: 14, fests: []}, {date: 15, fests: []}, {date: 16, fests: []}, {date: 17, fests: []}, {date: 18, fests: []}, {date: 19, fests: []}, {date: 20, fests: []}, {date: 21, fests: []}, {date: 22, fests: []}, {date: 23, fests: []}, {date: 24, fests: []}, {date: 25, fests: []}, {date: 26, fests: []}, {date: 27, fests: []}, {date: 28, fests: []}, {date: 29, fests: []}, {date: 30, fests: []}, {date: 31, fests: []}])
+
+const [fesId, setFesId] = useState(0)
+
+const dispatch = useAppDispatch();
+const state = useAppSelector((state) => state);
+
+useEffect(() => {
+  dispatch(getFesInfo(fesId))
+}, [fesId])
 
 // 현재 날짜 구하기
 let now = new Date();

--- a/pages/Schedule/infoSlice.tsx
+++ b/pages/Schedule/infoSlice.tsx
@@ -1,0 +1,55 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { preURL } from "../../preURL/preURL";
+
+interface InfoAtt {
+    photo: object,
+    nickname: string,
+    id: string
+}
+
+// Action
+export const getFesInfo = createAsyncThunk <InfoAtt, any>("schedule/getFesInfo", async (fesId, thunkAPI) => {
+    try{
+        const res = await axios.get(preURL.preURL+ "/api/festivals/"+fesId)
+        console.log("❕축제 정보 조회❕ ", res.data);
+        return res.data;
+    } catch (e) {
+        console.error("⚠️ 축제 정보 조회 ⚠️ ", e);
+        return thunkAPI.rejectWithValue(e);
+
+    }
+})
+
+  export const infoSlice = createSlice({
+    name: "info",
+    initialState: {
+        data: [],
+        loading: false,
+        error: false,
+      },
+    reducers: {    },
+    extraReducers: (builder) => {
+      builder
+        // 통신 중
+        .addCase(getFesInfo.pending, (state) => {
+          state.error = false;
+          state.loading = true;
+        })
+        // 통신 성공
+        .addCase(getFesInfo.fulfilled, (state, { payload }) => {
+          state.error = false;
+          state.loading = false;
+        //   state.data = payload;
+        })
+        // 통신 에러
+        .addCase(getFesInfo.rejected, (state, { payload }) => {
+        //   state.error = payload;
+          state.loading = false;
+        });
+    },
+  });
+
+  export const {} = infoSlice.actions;
+
+export default infoSlice.reducer;

--- a/pages/Schedule/styles.tsx
+++ b/pages/Schedule/styles.tsx
@@ -1,1 +1,38 @@
 import styled from "@emotion/styled";
+import { StyledDivColumn, StyledDivRow } from "../../Style/FlexBox";
+
+export const Span = styled.span`
+font-size: 3rem;
+font-weight: bold;
+`
+
+export const Calendar = styled(StyledDivRow)`
+height: 64rem;
+width: 91.3rem;
+flex-wrap: wrap;
+`
+
+export const DateBox = styled(StyledDivColumn)`
+height: 11.9rem;
+width: 9rem;
+background-color: ${(props: any) => ((props.id % 2 == 0) ? "#F5A547" : "#FDC88A" )};
+border-radius: 2rem;
+font-size: 3rem;
+font-weight: bold;
+justify-content: flex-start;
+padding: 2rem
+`
+
+export const DetailInfo = styled(StyledDivColumn)`
+height: 53.6rem;
+width: 34.7rem;
+background-color: #FFDD95;
+border-radius: 2rem;
+padding: 5rem;
+margin-left: 2.4rem;
+`
+
+export const Info = styled.span`
+font-size: 2.5rem;
+font-weight: bold;
+`

--- a/redux/store.ts
+++ b/redux/store.ts
@@ -3,13 +3,15 @@ import testSlice from "../reducers/TestSlice";
 import userReducer from "../pages/MyPage/userSlice"
 import writingSlice from "@pages/MyPage/writingSlice";
 import dipSlice from "@pages/MyPage/dipSlice";
+import infoSlice from "@pages/Schedule/infoSlice";
 
 export  const store = configureStore({
   reducer: {
     counter: testSlice,
     user: userReducer,
     dipping: dipSlice, 
-    wrting: writingSlice
+    wrting: writingSlice,
+    info: infoSlice
   },
 });
 


### PR DESCRIPTION
## 개요 :mag:
축제 일정 페이지 추가

## 작업사항 :memo:
**Schedule > index, styles.tsx & infoSlice, scheduleSlice.tsx**
- 디자인 추가
- 축제 일정 조회, 세부 정보 조회 API 추가
- 참조 오류 수정

## 구현화면 👓
<img width="1440" alt="스크린샷 2022-12-28 오후 9 26 27" src="https://user-images.githubusercontent.com/67596636/209812567-a7556761-de7b-44c2-9abc-0ca8ef777765.png">

